### PR TITLE
【FB】引数の指定順

### DIFF
--- a/bbs.php
+++ b/bbs.php
@@ -4,7 +4,7 @@
 	// $db = mysql_connect('mysql103.phy.lolipop.lan','LAA0673641','nexseed');
 
 	//接続するDBにonelin_bbsを選択
-	mysqli_select_db('oneline_bbs',$db);
+	mysqli_select_db('oneline_bbs',$db);　//<- 引数の指定が逆です
 	// mysql_select_db('LAA0673641-onelinebbs',$db);
 	
 


### PR DESCRIPTION
mysqli_select_dbは$db(接続オブジェクト）を先に指定して、後からDB名を指定します。
